### PR TITLE
add matchers support to AlertReaction for advanced alert conditions

### DIFF
--- a/config/crd/alertreaction.io_alertreactions.yaml
+++ b/config/crd/alertreaction.io_alertreactions.yaml
@@ -204,6 +204,60 @@ spec:
                 description: AlertName specifies the Prometheus alert name to react
                   to
                 type: string
+              matchers:
+                description: |-
+                  Matchers defines additional conditions that must be met for the alert to trigger this reaction
+                  All matchers must match for the reaction to be triggered
+                  If no matchers are specified, only the AlertName is used for matching
+                items:
+                  description: AlertMatcher defines conditions for matching alerts
+                    based on their attributes
+                  properties:
+                    name:
+                      description: Name of the alert attribute to match against (e.g.,
+                        "labels.instance", "annotations.severity", "status")
+                      type: string
+                    operator:
+                      allOf:
+                      - enum:
+                        - Equal
+                        - NotEqual
+                        - In
+                        - NotIn
+                        - Exists
+                        - DoesNotExist
+                        - GreaterThan
+                        - LessThan
+                        - Regex
+                        - NotRegex
+                      - enum:
+                        - Equal
+                        - NotEqual
+                        - In
+                        - NotIn
+                        - Exists
+                        - DoesNotExist
+                        - GreaterThan
+                        - LessThan
+                        - Regex
+                        - NotRegex
+                      description: |-
+                        Operator defines how to compare the alert attribute value with the expected value
+                        Supported operators: Equal, NotEqual, In, NotIn, Exists, DoesNotExist, GreaterThan, LessThan, Regex, NotRegex
+                      type: string
+                    values:
+                      description: |-
+                        Values are the expected values to match against (not required for Exists/DoesNotExist operators)
+                        For "In" and "NotIn" operators, multiple values can be specified
+                        For other operators, only the first value is used
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - name
+                  - operator
+                  type: object
+                type: array
               volumes:
                 description: |-
                   Volumes defines volumes that can be mounted by actions in this AlertReaction

--- a/docs/matchers.md
+++ b/docs/matchers.md
@@ -1,0 +1,154 @@
+# AlertReaction Matchers
+
+AlertReaction now supports advanced matching conditions through the `matchers` field. This allows you to specify fine-grained conditions for triggering reactions based on alert attributes beyond just the alert name.
+
+## Matcher Configuration
+
+Matchers are defined as an array of conditions that must **all** be satisfied for the reaction to trigger. If no matchers are specified, only the `alertName` is used for matching.
+
+```yaml
+spec:
+  alertName: "ServiceDown"
+  matchers:
+    - name: "labels.severity"
+      operator: Equal
+      values: ["critical"]
+    - name: "labels.service"
+      operator: In
+      values: ["web-server", "api-gateway"]
+```
+
+## Matcher Fields
+
+### `name` (required)
+The path to the alert attribute to match against. Common paths include:
+- `labels.<label-name>` - Match against alert labels
+- `annotations.<annotation-name>` - Match against alert annotations  
+- `status` - Match against alert status
+- `startsAt` - Match against alert start time
+- `endsAt` - Match against alert end time
+
+### `operator` (required)
+The comparison operator to use. Supported operators:
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `Equal` | Exact string match | `value == "critical"` |
+| `NotEqual` | String not equal | `value != "warning"` |
+| `In` | Value in list | `value in ["critical", "high"]` |
+| `NotIn` | Value not in list | `value not in ["low", "info"]` |
+| `Exists` | Attribute exists | Label/annotation is present |
+| `DoesNotExist` | Attribute missing | Label/annotation is not present |
+| `GreaterThan` | Numeric comparison | `value > "90"` |
+| `LessThan` | Numeric comparison | `value < "10"` |
+| `Regex` | Regular expression | `value matches ".*prod.*"` |
+| `NotRegex` | Negative regex | `value does not match ".*test.*"` |
+
+### `values` (optional)
+Array of values to match against. Not required for `Exists` and `DoesNotExist` operators.
+- For `In` and `NotIn`: Multiple values are supported
+- For other operators: Only the first value is used
+- For numeric operators: Values are converted to numbers for comparison
+
+## Examples
+
+### Basic Label Matching
+```yaml
+matchers:
+  - name: "labels.severity"
+    operator: Equal
+    values: ["critical"]
+```
+
+### Multiple Service Matching
+```yaml
+matchers:
+  - name: "labels.service"
+    operator: In
+    values: ["web-server", "api-gateway", "database"]
+```
+
+### Existence Check
+```yaml
+matchers:
+  - name: "labels.instance"
+    operator: Exists
+  - name: "annotations.runbook"
+    operator: DoesNotExist
+```
+
+### Numeric Thresholds
+```yaml
+matchers:
+  - name: "annotations.value"
+    operator: GreaterThan
+    values: ["90"]
+```
+
+### Regular Expression Matching
+```yaml
+matchers:
+  - name: "labels.instance"
+    operator: Regex
+    values: ["prod-.*-[0-9]+"]
+  - name: "labels.environment"
+    operator: NotRegex
+    values: [".*test.*", ".*staging.*"]
+```
+
+### Complex Example
+```yaml
+apiVersion: alerts.davidzimberknopf.io/v1alpha1
+kind: AlertReaction
+metadata:
+  name: production-critical-alerts
+spec:
+  alertName: "ServiceDown"
+  matchers:
+    # Must be critical severity
+    - name: "labels.severity"
+      operator: Equal
+      values: ["critical"]
+    
+    # Must be production environment
+    - name: "labels.environment"
+      operator: Equal
+      values: ["production"]
+    
+    # Must be one of our core services
+    - name: "labels.service"
+      operator: In
+      values: ["web-server", "api-gateway", "database", "cache"]
+    
+    # Must have a runbook
+    - name: "annotations.runbook"
+      operator: Exists
+    
+    # Exclude test instances
+    - name: "labels.instance"
+      operator: NotRegex
+      values: [".*test.*", ".*dev.*"]
+  
+  actions:
+    - name: "emergency-response"
+      image: "my-registry/emergency-responder:latest"
+      # ... action configuration
+```
+
+## Backwards Compatibility
+
+The `matchers` field is optional. Existing AlertReaction resources without matchers will continue to work exactly as before, matching only on the `alertName` field.
+
+## Matcher Evaluation Logic
+
+1. All matchers must evaluate to `true` for the reaction to trigger
+2. If any matcher evaluates to `false`, the reaction is skipped
+3. If no matchers are specified, only the `alertName` is checked
+4. Matchers are evaluated in the order they are specified (though all must pass)
+
+## Performance Considerations
+
+- Matchers are evaluated for every incoming alert
+- Regular expression matchers (`Regex`, `NotRegex`) are more expensive than simple equality checks
+- Consider using `In`/`NotIn` operators instead of multiple `Equal`/`NotEqual` matchers when possible
+- Place most selective matchers first to fail fast when possible

--- a/examples/matcher-example.yaml
+++ b/examples/matcher-example.yaml
@@ -1,0 +1,92 @@
+apiVersion: alerts.davidzimberknopf.io/v1alpha1
+kind: AlertReaction
+metadata:
+  name: critical-service-alert-reaction
+  namespace: default
+spec:
+  # The basic alert name to match
+  alertName: "ServiceDown"
+  
+  # Additional matchers for fine-grained control
+  matchers:
+    # Match alerts with severity label equal to "critical"
+    - name: "labels.severity"
+      operator: Equal
+      values: ["critical"]
+    
+    # Match alerts for specific services
+    - name: "labels.service"
+      operator: In
+      values: ["web-server", "api-gateway", "database"]
+    
+    # Ensure the alert has an instance label (exists check)
+    - name: "labels.instance"
+      operator: Exists
+    
+    # Match alerts where the runbook annotation contains "emergency"
+    - name: "annotations.runbook"
+      operator: Regex
+      values: [".*emergency.*"]
+  
+  # Actions to perform when all matchers are satisfied
+  actions:
+    - name: "send-notification"
+      image: "curlimages/curl:latest"
+      command: ["curl"]
+      args:
+        - "-X"
+        - "POST"
+        - "-H"
+        - "Content-Type: application/json"
+        - "-d"
+        - '{"text":"Critical service alert triggered for {{ .Labels.service }} on {{ .Labels.instance }}"}'
+        - "https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK"
+    
+    - name: "restart-service"
+      image: "bitnami/kubectl:latest"
+      command: ["kubectl"]
+      args:
+        - "rollout"
+        - "restart"
+        - "deployment/{{ .Labels.service }}"
+        - "-n"
+        - "production"
+      serviceAccountName: "alertreaction-restart-sa"
+
+---
+apiVersion: alerts.davidzimberknopf.io/v1alpha1
+kind: AlertReaction
+metadata:
+  name: memory-threshold-reaction
+  namespace: monitoring
+spec:
+  alertName: "HighMemoryUsage"
+  
+  # Match only when memory usage is above 90%
+  matchers:
+    # Check if the value annotation contains a percentage > 90
+    - name: "annotations.value"
+      operator: Regex
+      values: ["9[0-9]\\.[0-9]+%|100%"]
+    
+    # Match only production environment
+    - name: "labels.environment"
+      operator: Equal
+      values: ["production"]
+    
+    # Exclude test instances
+    - name: "labels.instance"
+      operator: NotRegex
+      values: [".*test.*", ".*staging.*"]
+  
+  actions:
+    - name: "scale-up"
+      image: "bitnami/kubectl:latest"
+      command: ["kubectl"]
+      args:
+        - "scale"
+        - "deployment/{{ .Labels.deployment }}"
+        - "--replicas=5"
+        - "-n"
+        - "{{ .Labels.namespace }}"
+      serviceAccountName: "alertreaction-scale-sa"


### PR DESCRIPTION
fix #1 

This pull request introduces advanced alert matching capabilities to the AlertReaction resource, allowing users to specify fine-grained conditions for triggering reactions based on alert attributes, not just the alert name. The main changes include the addition of the new `matchers` field to the API and CRD, supporting multiple match operators, and comprehensive documentation and examples for configuring matchers.

**API and CRD Enhancements:**

* Added the `AlertMatcher` struct and `MatchOperator` type to `alertreaction_types.go`, enabling users to specify match conditions on alert attributes using operators such as `Equal`, `In`, `Exists`, `Regex`, and more. This allows for complex matching logic beyond just the alert name.
* Updated the CRD schema in `alertreaction.io_alertreactions.yaml` to include the new `matchers` field under `spec`, with validation and descriptions for matcher configuration.

**Documentation:**

* Added `docs/matchers.md` with detailed instructions, field descriptions, operator explanations, examples, and performance considerations for using the new matcher functionality.

**Examples:**

* Provided `examples/matcher-example.yaml` with realistic AlertReaction configurations demonstrating the use of matchers for various scenarios, including label matching, existence checks, regex, and complex multi-condition reactions.

These changes are fully backwards compatible: the new `matchers` field is optional, so existing AlertReaction resources will continue to work as before, matching only on `alertName` if no matchers are specified.